### PR TITLE
Improve server error handling

### DIFF
--- a/server/analytics.ts
+++ b/server/analytics.ts
@@ -1,6 +1,7 @@
 import { Express, Request, Response } from "express";
 import { storage } from "./storage";
 import { z } from "zod";
+import { sendError } from "./utils/sendError";
 
 const analyticEventSchema = z.object({
   userId: z.number(),
@@ -23,14 +24,14 @@ export function setupAnalytics(app: Express) {
       res.status(200).json({ success: true });
     } catch (error) {
       console.error("Analytics tracking error:", error);
-      res.status(400).json({ error: "Invalid analytics data" });
+      sendError(res, 400, "Invalid analytics data");
     }
   });
 
   // Get user's activity history
   app.get("/api/analytics/user/:userId", async (req: Request, res: Response) => {
     if (!req.isAuthenticated()) {
-      return res.status(401).json({ error: "Unauthorized" });
+      return sendError(res, 401, "Unauthorized");
     }
     
     try {
@@ -38,14 +39,14 @@ export function setupAnalytics(app: Express) {
       
       // Only allow users to view their own analytics
       if (req.user?.id !== userId) {
-        return res.status(403).json({ error: "Forbidden" });
+        return sendError(res, 403, "Forbidden");
       }
       
       const actions = await storage.getActionsByUser(userId);
       res.status(200).json(actions);
     } catch (error) {
       console.error("Error fetching user analytics:", error);
-      res.status(500).json({ error: "Failed to fetch analytics" });
+      sendError(res, 500, "Failed to fetch analytics");
     }
   });
 
@@ -56,7 +57,7 @@ export function setupAnalytics(app: Express) {
       res.status(200).json(popularContent);
     } catch (error) {
       console.error("Error fetching popular content:", error);
-      res.status(500).json({ error: "Failed to fetch popular content" });
+      sendError(res, 500, "Failed to fetch popular content");
     }
   });
 }

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -7,6 +7,7 @@ import { promisify } from "util";
 import { storage } from "./storage";
 import { User as SelectUser } from "@shared/schema";
 import { Request, Response, NextFunction } from "express";
+import { sendError } from "./utils/sendError";
 
 declare global {
   namespace Express {
@@ -116,12 +117,12 @@ export function setupAuth(app: Express) {
       const { username, password, name, bio, profilePicture } = req.body;
 
       if (!username || !password || !name) {
-        return res.status(400).json({ error: "Missing required fields" });
+        return sendError(res, 400, "Missing required fields");
       }
 
       const existingUser = await storage.getUserByUsername(username);
       if (existingUser) {
-        return res.status(400).json({ error: "Username already exists" });
+        return sendError(res, 400, "Username already exists");
       }
 
       const hashedPassword = await hashPassword(password);
@@ -143,7 +144,7 @@ export function setupAuth(app: Express) {
       });
     } catch (err: any) {
       console.error("Registration error:", err);
-      res.status(500).json({ error: "Registration failed" });
+      sendError(res, 500, "Registration failed");
     }
   });
 
@@ -157,7 +158,7 @@ export function setupAuth(app: Express) {
       }
       if (!user) {
         console.log("Login failed:", info?.message || "Authentication failed");
-        return res.status(401).json({ error: info?.message || "Authentication failed" });
+        return sendError(res, 401, info?.message || "Authentication failed");
       }
 
       console.log("User authenticated, creating session...");
@@ -189,7 +190,7 @@ export function setupAuth(app: Express) {
     console.log("Is authenticated:", req.isAuthenticated());
 
     if (!req.isAuthenticated()) {
-      return res.status(401).json({ error: "Not authenticated" });
+      return sendError(res, 401, "Not authenticated");
     }
 
     // Return user without password
@@ -207,7 +208,7 @@ export function setupAuth(app: Express) {
     console.log("Headers:", req.headers);
 
     if (!req.isAuthenticated()) {
-      return res.status(401).json({ error: "Not authenticated" });
+      return sendError(res, 401, "Not authenticated");
     }
 
     // Return user without password
@@ -233,5 +234,5 @@ export const authenticate = (req: Request, res: Response, next: NextFunction) =>
   }
 
   console.log('Authentication failed for:', req.method, req.path);
-  res.status(401).json({ error: 'Not authenticated' });
+  sendError(res, 401, 'Not authenticated');
 };

--- a/server/index.ts
+++ b/server/index.ts
@@ -135,7 +135,3 @@ app.use((req, res, next) => {
   console.error('Unhandled server startup error:', error);
   process.exit(1);
 });
-
-
-
-// This was moved to the wrong location - removing from here

--- a/server/utils/sendError.ts
+++ b/server/utils/sendError.ts
@@ -1,0 +1,3 @@
+export function sendError(res: import('express').Response, status: number, message: string) {
+  res.status(status).json({ error: message });
+}


### PR DESCRIPTION
## Summary
- create simple `sendError` helper for consistent JSON error replies
- use the helper in analytics and auth routes
- remove stray comment from server startup file
- handle auth errors in analytics with `sendError`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872af06a7ec832da14b813c9f3c2e38